### PR TITLE
Fix msa slicing to account for insertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,10 @@ example*
 test*
 data
 results
-old
-*old*
+old_files
 */analysis/pnas_resubmission
 input/gene_fasta_original
+analysis
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/fragfold/create_fragment_msa.py
+++ b/fragfold/create_fragment_msa.py
@@ -13,6 +13,8 @@ def main(args):
     fragment_start_range = (args.fragment_ntermres_start,args.fragment_ntermres_final)
     fragment_length = args.fragment_length
     protein_copies = args.protein_copies
+    fragment_single_sequence = args.fragment_single_sequence
+    fragment_shuffle_sequence = args.fragment_shuffle_sequence
 
     protein_range = (args.protein_ntermres,args.protein_ctermres)
 
@@ -23,7 +25,9 @@ def main(args):
                                                                 protein_range,
                                                                 fragment_start_range,
                                                                 fragment_length,
-                                                                protein_copies)
+                                                                protein_copies,
+                                                                fragment_single_sequence,
+                                                                fragment_shuffle_sequence)
     else:
         # Create heteromeric interaction MSAs: fragments of protein A + full-length protein B
 
@@ -37,7 +41,9 @@ def main(args):
                                                                         protein_range,
                                                                         fragment_start_range,
                                                                         fragment_length,
-                                                                        protein_copies)
+                                                                        protein_copies,
+                                                                        fragment_single_sequence,
+                                                                        fragment_shuffle_sequence)
     with open("a3m_list.txt","w") as file:
         for path in msa_path_list:
             file.write(str(path)+"\n")
@@ -94,6 +100,18 @@ if __name__ == "__main__":
         type=int,
         help="The number of copies of the full-length protein",
         default=1
+    )
+    parser.add_argument(
+        "--fragment_single_sequence",
+        type=bool,
+        help="If true, will remove the MSA for the fragment and model using the query sequence",
+        default=False,
+    )
+    parser.add_argument(
+        "--fragment_shuffle_sequence",
+        type=bool,
+        help="If true, will remove the MSA for the fragment and model using the shuffled query sequence",
+        action=False,
     )
     args = parser.parse_args()
     main(args)

--- a/fragfold/create_fragment_msa.py
+++ b/fragfold/create_fragment_msa.py
@@ -15,6 +15,7 @@ def main(args):
     protein_copies = args.protein_copies
     fragment_single_sequence = args.fragment_single_sequence
     fragment_shuffle_sequence = args.fragment_shuffle_sequence
+    print(fragment_single_sequence,fragment_shuffle_sequence)
 
     protein_range = (args.protein_ntermres,args.protein_ctermres)
 
@@ -103,15 +104,13 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--fragment_single_sequence",
-        type=bool,
+        action='store_true',
         help="If true, will remove the MSA for the fragment and model using the query sequence",
-        default=False,
     )
     parser.add_argument(
         "--fragment_shuffle_sequence",
-        type=bool,
+        action='store_true',
         help="If true, will remove the MSA for the fragment and model using the shuffled query sequence",
-        action=False,
     )
     args = parser.parse_args()
     main(args)

--- a/fragfold/src/a3m_tools.py
+++ b/fragfold/src/a3m_tools.py
@@ -1,0 +1,211 @@
+from pathlib import Path
+from typing import List
+from typing import Tuple
+from typing import Union
+
+class ProteinSequence:
+    def __init__(self, header: str, sequence: str):
+        self.header = header
+        self.seq_str = sequence
+
+    def __str__(self):
+        return f">{self.header}\n{self.seq_str}"
+
+    def __repr__(self):
+        return f">{self.header}\n{self.seq_str}"
+
+    def __len__(self):
+        return len(self.seq_str)
+
+    def __getitem__(self, index):
+        """This should allow for slicing of the sequence"""
+        return ProteinSequence(self.header, self.seq_str[index])
+
+    def __add__(self, other):
+        """This should allow for concatenation of the sequence"""
+        if isinstance(other, ProteinSequence):
+            return ProteinSequence(self.header, self.seq_str + other.seq_str)
+        elif isinstance(other, str):
+            return ProteinSequence(self.header, self.seq_str + other)
+        else:
+            raise TypeError(f"Cannot concatenate ProteinSequence with {type(other)}")
+
+    def __radd__(self, other):
+        """This should allow for concatenation of the sequence"""
+        if isinstance(other, ProteinSequence):
+            return ProteinSequence(self.header, other.seq_str + self.seq_str)
+        elif isinstance(other, str):
+            return ProteinSequence(self.header, other + self.seq_str)
+        else:
+            raise TypeError(f"Cannot concatenate ProteinSequence with {type(other)}")
+
+
+def parse_header(header_line: str):
+    header = header_line.rstrip()
+    assert header.startswith(
+        ">"
+    ), f"Expected header to start with >, instead saw: {header_line}"
+    return header[1:]
+
+
+def import_a3m(filepath):
+    with open(filepath) as f:
+        info_line = f.readline().rstrip()
+        if not info_line.startswith("#"):
+            raise ValueError(
+                f"{filepath} should begin with #, instead saw: {info_line}"
+            )
+        lines = [i.strip() for i in f.readlines()]
+        query_header = parse_header(lines[0])
+        query_sequence = lines[1].rstrip()
+        query = ProteinSequence(query_header, query_sequence)
+        sequences = []
+        for c in range(2, len(lines), 2):
+            name = parse_header(lines[c])
+            seq = lines[c + 1].rstrip()
+            sequences.append(ProteinSequence(name, seq))
+    return info_line, query, sequences
+
+
+def parse_info_line(info_line: str):
+    """ """
+    info = info_line.split("\t")
+    assert (
+        len(info) == 2
+    ), f"Expected 2 fields separated by a tab in the info line, instead saw: {info_line}"
+    query_seq_lengths = info[0][1:].split(",")
+    query_seq_cardinality = info[1].split(",")
+    return query_seq_lengths, query_seq_cardinality
+
+
+class MSAa3m:
+
+    def __init__(
+        self, info_line: str, query: ProteinSequence, sequences: List[ProteinSequence]
+    ):
+        self.info_line = info_line
+        self.query = query
+        assert "-" not in self.query.seq_str, "Query sequence should not contain gaps"
+        assert all(
+            [i.isupper() for i in self.query.seq_str]
+        ), "Query sequence should not contain insertions"
+        self.sequences = sequences
+        self.query_seq_lengths, self.query_seq_cardinality = self._parse_info_line(
+            self.info_line
+        )
+
+    def __str__(self):
+        msa_str = f"{self.info_line}\n{self.query}\n"
+        for seq in self.sequences:
+            msa_str += f"{seq}\n"
+        return msa_str
+
+    def __repr__(self):
+        msa_str = f"{self.info_line}\n{self.query}\n"
+        for seq in self.sequences:
+            msa_str += f"{seq}\n"
+        return msa_str
+
+    @classmethod
+    def from_a3m_file(cls, file_path: Union[str, Path]):
+        info_line, query, sequences = import_a3m(file_path)
+        return cls(info_line, query, sequences)
+
+    @staticmethod
+    def _parse_info_line(info_line: str):
+        """
+        #157,235	1,1
+        #398	1
+        """
+        info = info_line.split("\t")
+        assert (
+            len(info) == 2
+        ), f"Expected 2 fields separated by a tab in the info line, instead saw: {info_line}"
+        query_seq_lengths = info[0][1:].split(",")
+        query_seq_cardinality = info[1].split(",")
+        return query_seq_lengths, query_seq_cardinality
+
+    def _slice_alignment(self, start, end):
+        if len(self.query_seq_lengths) > 1:
+            raise NotImplementedError(
+                "Cannot slice alignment with multiple query sequences yet"
+            )
+        sliced_query = ProteinSequence(self.query.header, self.query.seq_str[start:end])
+        new_info_line = f"#{len(sliced_query.seq_str)}\t{self.query_seq_cardinality[0]}"
+        sliced_sequences = []
+        for seq in self.sequences:
+            core_index = 0
+            sliced_seq = ""
+            for char in seq.seq_str:
+                if core_index >= end:
+                    break
+                if char.isupper():
+                    if core_index >= start:
+                        sliced_seq += char
+                    core_index += 1
+                elif char.islower():
+                    if core_index > start:
+                        sliced_seq += char
+                elif char == "-":
+                    if core_index >= start:
+                        sliced_seq += char
+                    core_index += 1
+            sliced_sequences.append(ProteinSequence(seq.header, sliced_seq))
+        return MSAa3m(new_info_line, sliced_query, sliced_sequences)
+
+    def __getitem__(self, index):
+        """This should allow for slicing of the sequence"""
+        if isinstance(index, slice):
+            return self._slice_alignment(index.start, index.stop)
+        elif isinstance(index, int):
+            return self._slice_alignment(index, index + 1)
+        else:
+            raise TypeError("Only integers and slices are valid indices for A3M_MSA")
+
+    def __add__(self, other):
+        """This should allow for concatenation of the msas."""
+        if isinstance(other, MSAa3m):
+            new_info_line = f"#{','.join(self.query_seq_lengths)},{','.join(other.query_seq_lengths)}\t{','.join(self.query_seq_cardinality)},{','.join(other.query_seq_cardinality)}"
+
+            # change other query header to a new index.
+            # create a new object to avoid changing the original
+            last_self_int = [int(i) for i in self.query.header.split("\t")][-1]
+            other_ints = [int(i) for i in other.query.header.split("\t")]
+            c = last_self_int + 1
+            other_int_map = {}
+            new_other_int_list = []
+            for i in other_ints:
+                other_int_map[str(i)] = str(c)
+                new_other_int_list.append(str(c))
+                c += 1
+            new_other_header = "\t".join(new_other_int_list)
+            other_query = ProteinSequence(new_other_header, other.query.seq_str)
+
+            new_query = ProteinSequence(
+                f"{self.query.header}\t{other_query.header}",
+                f"{self.query.seq_str}{other_query.seq_str}",
+            )
+            new_sequences = []
+            if len(self.query_seq_lengths) == 1:
+                new_sequences.append(self.query + "-" * len(other_query))
+            for seq in self.sequences:
+                new_seq = seq + "-" * len(other_query)
+                if not all([i == "-" for i in new_seq.seq_str]):
+                    new_sequences.append(new_seq)
+            if len(other.query_seq_lengths) == 1:
+                new_sequences.append("-" * len(self.query) + other_query)
+            for seq in other.sequences:
+                new_seq = "-" * len(self.query) + seq
+                if new_seq.header in other_int_map.keys():
+                    new_seq.header = other_int_map[new_seq.header]
+                if not all([i == "-" for i in new_seq.seq_str]):
+                    new_sequences.append(new_seq)
+            # add the original 2 queries back to the MSA but only
+            # if the MSA was not previously concatenated
+            return MSAa3m(new_info_line, new_query, new_sequences)
+        else:
+            raise TypeError(f"Cannot concatenate A3M_MSA with {type(other)}")
+
+    def save(self, filepath):
+        with open(filepath, "w") as f:
+            f.write(str(self))

--- a/fragfold/src/a3m_tools.py
+++ b/fragfold/src/a3m_tools.py
@@ -67,15 +67,15 @@ def import_a3m(filepath):
     return info_line, query, sequences
 
 
-def parse_info_line(info_line: str):
-    """ """
-    info = info_line.split("\t")
-    assert (
-        len(info) == 2
-    ), f"Expected 2 fields separated by a tab in the info line, instead saw: {info_line}"
-    query_seq_lengths = info[0][1:].split(",")
-    query_seq_cardinality = info[1].split(",")
-    return query_seq_lengths, query_seq_cardinality
+# def parse_info_line(info_line: str):
+#     """ """
+#     info = info_line.split("\t")
+#     assert (
+#         len(info) == 2
+#     ), f"Expected 2 fields separated by a tab in the info line, instead saw: {info_line}"
+#     query_seq_lengths = info[0][1:].split(",")
+#     query_seq_cardinality = info[1].split(",")
+#     return query_seq_lengths, query_seq_cardinality
 
 
 class MSAa3m:
@@ -105,6 +105,13 @@ class MSAa3m:
         for seq in self.sequences:
             msa_str += f"{seq}\n"
         return msa_str
+    
+    def set_cardinality(self,n_copies):
+        if len(self.query_seq_lengths) > 1:
+            raise NotImplementedError(
+                "Cannot adjust cardinality with multiple query sequences yet"
+            )
+        self.query_seq_cardinality = n_copies
 
     @classmethod
     def from_a3m_file(cls, file_path: Union[str, Path]):
@@ -117,11 +124,12 @@ class MSAa3m:
         #157,235	1,1
         #398	1
         """
-        info = info_line.split("\t")
+        assert info_line[0] == '#', f"Expected a '#' at the beginning of the info line"
+        info = info_line[1:].split("\t")
         assert (
             len(info) == 2
         ), f"Expected 2 fields separated by a tab in the info line, instead saw: {info_line}"
-        query_seq_lengths = info[0][1:].split(",")
+        query_seq_lengths = info[0].split(",")
         query_seq_cardinality = info[1].split(",")
         return query_seq_lengths, query_seq_cardinality
 
@@ -133,10 +141,10 @@ class MSAa3m:
         sliced_query = ProteinSequence(self.query.header, self.query.seq_str[start:end])
         new_info_line = f"#{len(sliced_query.seq_str)}\t{self.query_seq_cardinality[0]}"
         sliced_sequences = []
-        for seq in self.sequences:
+        for seq_idx,seq in enumerate(self.sequences):
             core_index = 0
             sliced_seq = ""
-            for char in seq.seq_str:
+            for char_idx,char in enumerate(seq.seq_str):
                 if core_index >= end:
                     break
                 if char.isupper():
@@ -150,6 +158,8 @@ class MSAa3m:
                     if core_index >= start:
                         sliced_seq += char
                     core_index += 1
+                else:
+                    raise ValueError(f"Character {char} at position {char_idx} in sequence {seq_idx} with name {seq.header} is not recognized")
             sliced_sequences.append(ProteinSequence(seq.header, sliced_seq))
         return MSAa3m(new_info_line, sliced_query, sliced_sequences)
 
@@ -163,48 +173,49 @@ class MSAa3m:
             raise TypeError("Only integers and slices are valid indices for A3M_MSA")
 
     def __add__(self, other):
-        """This should allow for concatenation of the msas."""
-        if isinstance(other, MSAa3m):
-            new_info_line = f"#{','.join(self.query_seq_lengths)},{','.join(other.query_seq_lengths)}\t{','.join(self.query_seq_cardinality)},{','.join(other.query_seq_cardinality)}"
-
-            # change other query header to a new index.
-            # create a new object to avoid changing the original
-            last_self_int = [int(i) for i in self.query.header.split("\t")][-1]
-            other_ints = [int(i) for i in other.query.header.split("\t")]
-            c = last_self_int + 1
-            other_int_map = {}
-            new_other_int_list = []
-            for i in other_ints:
-                other_int_map[str(i)] = str(c)
-                new_other_int_list.append(str(c))
-                c += 1
-            new_other_header = "\t".join(new_other_int_list)
-            other_query = ProteinSequence(new_other_header, other.query.seq_str)
-
-            new_query = ProteinSequence(
-                f"{self.query.header}\t{other_query.header}",
-                f"{self.query.seq_str}{other_query.seq_str}",
-            )
-            new_sequences = []
-            if len(self.query_seq_lengths) == 1:
-                new_sequences.append(self.query + "-" * len(other_query))
-            for seq in self.sequences:
-                new_seq = seq + "-" * len(other_query)
-                if not all([i == "-" for i in new_seq.seq_str]):
-                    new_sequences.append(new_seq)
-            if len(other.query_seq_lengths) == 1:
-                new_sequences.append("-" * len(self.query) + other_query)
-            for seq in other.sequences:
-                new_seq = "-" * len(self.query) + seq
-                if new_seq.header in other_int_map.keys():
-                    new_seq.header = other_int_map[new_seq.header]
-                if not all([i == "-" for i in new_seq.seq_str]):
-                    new_sequences.append(new_seq)
-            # add the original 2 queries back to the MSA but only
-            # if the MSA was not previously concatenated
-            return MSAa3m(new_info_line, new_query, new_sequences)
-        else:
+        """This should allow for concatenation of the msas (to yield an unpaired msa)."""
+        if not isinstance(other, MSAa3m):
             raise TypeError(f"Cannot concatenate A3M_MSA with {type(other)}")
+        
+        # create new info line combining previous ones
+        new_info_line = f"#{','.join(self.query_seq_lengths)},{','.join(other.query_seq_lengths)}\t{','.join(self.query_seq_cardinality)},{','.join(other.query_seq_cardinality)}"
+
+        # update other query header to a new index
+        # create a new object to avoid changing the original
+        last_self_int = [int(i) for i in self.query.header.split("\t")][-1]
+        other_ints = [int(i) for i in other.query.header.split("\t")]
+        c = last_self_int + 1
+        other_int_map = {}
+        new_other_int_list = []
+        for i in other_ints:
+            other_int_map[str(i)] = str(c)
+            new_other_int_list.append(str(c))
+            c += 1
+        new_other_header = "\t".join(new_other_int_list)
+        other_query = ProteinSequence(new_other_header, other.query.seq_str)
+
+        new_query = ProteinSequence(
+            f"{self.query.header}\t{other_query.header}",
+            f"{self.query.seq_str}{other_query.seq_str}",
+        )
+        new_sequences = []
+        # add the original 2 queries back to the MSA but only
+        # if the MSA was not previously concatenated
+        if len(self.query_seq_lengths) == 1:
+            new_sequences.append(self.query + "-" * len(other_query))
+        for seq in self.sequences:
+            new_seq = seq + "-" * len(other_query)
+            if not all([i == "-" for i in new_seq.seq_str]):
+                new_sequences.append(new_seq)
+        if len(other.query_seq_lengths) == 1:
+            new_sequences.append("-" * len(self.query) + other_query)
+        for seq in other.sequences:
+            new_seq = "-" * len(self.query) + seq
+            if new_seq.header in other_int_map.keys():
+                new_seq.header = other_int_map[new_seq.header]
+            if not all([i == "-" for i in new_seq.seq_str]):
+                new_sequences.append(new_seq)
+        return MSAa3m(new_info_line, new_query, new_sequences)
 
     def save(self, filepath):
         with open(filepath, "w") as f:

--- a/fragfold/src/colabfold_create_msa.py
+++ b/fragfold/src/colabfold_create_msa.py
@@ -29,6 +29,7 @@ def shuffleSeq(seq,maxPercentIdentity=0.3):
 def subsampleMSA(msa: a3m_tools.MSAa3m, subsample: int):
     # subsample the MSA
     if subsample > 0:
+        print("Subsampling MSA")
         msa.sequences = msa.sequences[:subsample]
     return msa
 

--- a/fragfold/src/colabfold_create_msa.py
+++ b/fragfold/src/colabfold_create_msa.py
@@ -4,34 +4,9 @@ from pathlib import Path
 import os
 import random
 from multiprocessing import Pool
+from fragfold.src import a3m_tools
+import copy
 
-def readFastaLines(file):
-    header = file.readline().rstrip()
-    if header != '' and not header.startswith('>'):
-        raise ValueError('Header line in FASTA should begin with >, instead saw:'+header)
-    sequence = file.readline().rstrip()
-    return header,sequence
-
-def extractSubsequence(sequence,seqRange:tuple):
-    # Remember: residue number is 1-indexed, but the sequence is zero-indexed
-    return sequence[seqRange[0]-1:seqRange[1]]
-
-def hasGaps(sequence,gapchar:str='-'):
-    # search for gaps within the sequence (between non-gap chars)
-    return sum([x for x in map(lambda x: 1 if x != '' else 0,sequence.split(gapchar))]) > 1
-
-def hasLower(sequence):
-    for a in sequence:
-        if a.islower():
-            return True
-    return False
-
-def countLower(sequence):
-    count = 0
-    for a in sequence:
-        if a.islower():
-            count+=1
-    return count
 
 def calcHammingDistance(s1,s2):
     assert len(s1) == len(s2)
@@ -50,116 +25,93 @@ def shuffleSeq(seq,maxPercentIdentity=0.3):
         # print(shuffled_seq,hammingDistance)
     return shuffled_seq
 
-def createMSA(inputMSA: str, protein_range: tuple, fragment_range: tuple, subsample: int, a3m_output_path: str,
-              protein_copies: int = 1, fragment_single_sequence=False, fragment_shuffle=False):
-    full_query_seq = ''
-    new_info_line = ''
 
-    with open(inputMSA,'r') as input_file, open(a3m_output_path,'w') as output_file:
-        info_line = input_file.readline().rstrip()
-        # print('info line:',info_line)
-        if not info_line.startswith('#'):
-            raise ValueError('File should begin with #, instead saw'+info_line)
-            
-        # First line is whole protein sequence
-        header,whole_sequence = readFastaLines(input_file)
-        query_protein_sequence = extractSubsequence(whole_sequence,protein_range)
-        query_fragment_sequence = extractSubsequence(whole_sequence,fragment_range)
-        if fragment_shuffle:
-            query_fragment_sequence = shuffleSeq(query_fragment_sequence)
-        full_query_seq = query_protein_sequence + query_fragment_sequence
-        new_info_line = f"#{len(query_protein_sequence)},{len(query_fragment_sequence)}\t{protein_copies},1"+'\n'
-        
-        output_file.write(new_info_line)
-        output_file.write('>101\t102\n')
-        output_file.write(full_query_seq+'\n')
-            
-        count = 1
-        # Remaining lines are the matches from the MSA
-        while header != '':
-            header,sequence = readFastaLines(input_file)
-            if subsample > 0 and count == subsample:
-                break
-            
-            # Get the protein/fragment sequence
-            protein_sequence = extractSubsequence(sequence,protein_range)
-            fragment_sequence = extractSubsequence(sequence,fragment_range)
+def subsampleMSA(msa: a3m_tools.MSAa3m, subsample: int):
+    # subsample the MSA
+    if subsample > 0:
+        msa.sequences = msa.sequences[:subsample]
+    return msa
 
-            if protein_sequence.replace('-','') != '':
-                new_header = header + '\t101\n'
-                new_protein_sequence = protein_sequence.ljust(len(full_query_seq),'-') 
-                new_protein_sequence = new_protein_sequence + '-'*countLower(protein_sequence) + '\n'
-                output_file.write(new_header)
-                output_file.write(new_protein_sequence)
-            if fragment_sequence.replace('-','') != '' and not hasGaps(fragment_sequence) and not (fragment_single_sequence or fragment_shuffle):
-                new_header = header + '\t102\n'
-                new_fragment_sequence = fragment_sequence.rjust(len(full_query_seq),'-')
-                new_fragment_sequence = new_fragment_sequence + '-'*countLower(fragment_sequence) + '\n'
-                output_file.write(new_header)
-                output_file.write(new_fragment_sequence)
-            count+=1
 
-def createMSAHeteromicInteraction(fullLengthProteinMSA: str, protein_range: tuple, fragmentProteinMSA: str, fragment_range: tuple, subsample: int, a3m_output_path: str, protein_copies: int = 1,
-                                  fragmentSingleSequence=False, fragmentShuffle=False):
-    full_query_seq = ''
-    new_info_line = ''
+def createMSA(
+    inputMSA: str, 
+    protein_range: tuple, 
+    fragment_range: tuple, 
+    subsample: int, 
+    a3m_output_path: str,
+    protein_copies: int = 1, 
+    fragment_single_sequence=False, 
+    fragment_shuffle=False
+):
+    msa = a3m_tools.MSAa3m.from_a3m_file(inputMSA)
+    # assuming that `protein_range` and `fragment_range` are 1-based
+    protein_msa = msa[protein_range[0]-1:protein_range[1]]
+    fragment_msa = msa[fragment_range[0]-1:fragment_range[1]]
+    if fragment_shuffle:
+        # get rid of all but the query sequence in the fragment MSA
+        # shuffle the query sequence
+        shuffled_query = a3m_tools.ProteinSequence(
+            fragment_msa.query.header,
+            shuffleSeq(fragment_msa.query.seq_str)
+        )
+        fragment_msa = a3m_tools.MSAa3m(
+            fragment_msa.info_line, 
+            shuffled_query, 
+            []
+        )
+    if fragment_single_sequence:
+        # get rid of all but the query sequence in the fragment MSA
+        fragment_msa = a3m_tools.MSAa3m(
+            fragment_msa.info_line, 
+            fragment_msa.query, 
+            []
+        )
+    protein_msa = subsampleMSA(protein_msa,subsample)
+    fragment_msa = subsampleMSA(fragment_msa,subsample)
+    combined_msa = protein_msa + fragment_msa
+    combined_msa.save(a3m_output_path)
 
-    with open(fullLengthProteinMSA,'r') as fulllength_input_file, open(fragmentProteinMSA,'r') as fragment_input_file, open(a3m_output_path,'w') as output_file:
-        info_line = fulllength_input_file.readline().rstrip()
-        if not info_line.startswith('#'):
-            raise ValueError(f"{fullLengthProteinMSA} should begin with #, instead saw'+info_line")
-        info_line = fragment_input_file.readline().rstrip()
-        if not info_line.startswith('#'):
-            raise ValueError(f"{fragmentProteinMSA} should begin with #, instead saw'+info_line")
 
-        # First line in the full-length msa is whole protein sequence
-        fulllength_header,whole_sequence = readFastaLines(fulllength_input_file)
-        query_protein_sequence = extractSubsequence(whole_sequence,protein_range)
-        # First line in fragment msa is the whole sequence of the protein that was broken into fragments
-        fragment_header,whole_fragmented_sequence = readFastaLines(fragment_input_file)
-        query_fragment_sequence = extractSubsequence(whole_fragmented_sequence,fragment_range)
-        if fragmentShuffle:
-            query_fragment_sequence = shuffleSeq(query_fragment_sequence)
-        full_query_seq = query_protein_sequence + query_fragment_sequence
-        new_info_line = f"#{len(query_protein_sequence)},{len(query_fragment_sequence)}\t{protein_copies},1"+'\n'
-        
-        output_file.write(new_info_line)
-        output_file.write('>101\t102\n')
-        output_file.write(full_query_seq+'\n')
-            
-        # Remaining lines are the matches from the MSAs
-        # First get full-length MSA entries
-        count = 1
-        while fulllength_header != '':
-            fulllength_header,sequence = readFastaLines(fulllength_input_file)
-            if subsample > 0 and count == subsample:
-                break
-            # Get the protein/fragment sequence
-            protein_sequence = extractSubsequence(sequence,protein_range)
-            if protein_sequence.replace('-','') != '':
-                new_header = fulllength_header + '\t101\n'
-                new_protein_sequence = protein_sequence.ljust(len(full_query_seq),'-') 
-                new_protein_sequence = new_protein_sequence + '-'*countLower(protein_sequence) + '\n'
-                output_file.write(new_header)
-                output_file.write(new_protein_sequence)
-            count+=1
-        # Next get fragment MSA entries
-        count = 1
-        while fragment_header != '' and not (fragmentSingleSequence or fragmentShuffle):
-            fragment_header,sequence = readFastaLines(fragment_input_file)
-            if subsample > 0 and count == subsample:
-                break
-            # Get the protein/fragment sequence
-            fragment_sequence = extractSubsequence(sequence,fragment_range)
-            if fragment_sequence.replace('-','') != '' and not hasGaps(fragment_sequence):
-                new_header = fragment_header + '\t102\n'
-                new_fragment_sequence = fragment_sequence.rjust(len(full_query_seq),'-')
-                if fragmentShuffle:
-                    new_fragment_sequence = shuffleSeq(new_fragment_sequence)
-                new_fragment_sequence = new_fragment_sequence + '-'*countLower(fragment_sequence) + '\n'
-                output_file.write(new_header)
-                output_file.write(new_fragment_sequence)
-            count+=1
+def createMSAHeteromicInteraction(
+    fullLengthProteinMSA: str, 
+    protein_range: tuple, 
+    fragmentProteinMSA: str, 
+    fragment_range: tuple, 
+    subsample: int, 
+    a3m_output_path: str, 
+    protein_copies: int = 1,
+    fragmentSingleSequence=False, 
+    fragmentShuffle=False
+):
+    protein_msa = a3m_tools.MSAa3m.from_a3m_file(fullLengthProteinMSA)
+    # assuming that `protein_range` and `fragment_range` are 1-based
+    protein_msa = protein_msa[protein_range[0]-1:protein_range[1]]
+
+    fragment_msa = a3m_tools.MSAa3m.from_a3m_file(fragmentProteinMSA)
+    fragment_msa = fragment_msa[fragment_range[0]-1:fragment_range[1]]
+    if fragmentShuffle:
+        # get rid of all but the query sequence in the fragment MSA
+        # shuffle the query sequence
+        shuffled_query = a3m_tools.ProteinSequence(
+            fragment_msa.query.header,
+            shuffleSeq(fragment_msa.query.seq_str)
+        )
+        fragment_msa = a3m_tools.MSAa3m(
+            fragment_msa.info_line, 
+            shuffled_query, 
+            []
+        )
+    if fragmentSingleSequence:
+        # get rid of all but the query sequence in the fragment MSA
+        fragment_msa = a3m_tools.MSAa3m(
+            fragment_msa.info_line, 
+            fragment_msa.query, 
+            []
+        )
+    protein_msa = subsampleMSA(protein_msa,subsample)
+    fragment_msa = subsampleMSA(fragment_msa,subsample)
+    combined_msa = protein_msa + fragment_msa
+    combined_msa.save(a3m_output_path)
 
 def readA3MProteinLength(a3m_path):
     with open(a3m_path,'r') as file:

--- a/nextflow/modules.nf
+++ b/nextflow/modules.nf
@@ -77,7 +77,8 @@ process colabfold {
     colabfold_batch !{a3m_concat} . \
         --data !{alphafold_params_dir} \
         --model-type !{model_type} \
-        --pair-mode !{pair_mode}
+        --pair-mode !{pair_mode} \
+        --num-models !{num_models}
     '''
 }
 

--- a/nextflow/modules.nf
+++ b/nextflow/modules.nf
@@ -46,6 +46,10 @@ process process_msa {
 
     shell:
     '''
+    # set arg vars
+    if [[ !{fragment_single_sequence} == true ]]; then arg1="--fragment_single_sequence"; else arg1=""; fi
+    if [[ !{fragment_shuffle_sequence} == true ]]; then arg2="--fragment_shuffle_sequence"; else arg2=""; fi
+
     python !{repo_dir}/fragfold/create_fragment_msa.py \
         --fragment_a3m_input !{a3m} \
         --fragment_ntermres_start !{fragment_ntermres_start} \
@@ -54,7 +58,9 @@ process process_msa {
         --protein_a3m_input !{protein_a3m_input} \
         --protein_ntermres !{protein_ntermres} \
         --protein_ctermres !{protein_ctermres} \
-        --protein_copies !{protein_copies}
+        --protein_copies !{protein_copies} \
+        $arg1 \
+        $arg2 \
     '''
 }
 

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -1,7 +1,7 @@
 // Groovy syntax https://www.cheat-sheets.org/saved-copy/rc015-groovy_online.pdf
 
 // Define system-specific variables for all processes
-executor.queueSize = 50
+executor.queueSize = 30
 executor.conda = '/home/gridsan/sswanson/mambaforge/envs/fragfold'
 env.repo_dir = '/data1/groups/keatinglab/swans/savinovCollaboration/FragFold'
 env.colabfold_dir = '/home/gridsan/sswanson/localcolabfold/colabfold-conda'
@@ -10,9 +10,9 @@ env.alphafold_params_dir = '/home/gridsan/sswanson/localcolabfold/colabfold'
 // Parameters that general don't change (but you can adjust to experiment)
 env.model_type = 'alphafold2_ptm' //alt: alphafold2_multimer_v1 alphafold2_multimer_v2 alphafold2_multimer_v3
 env.pair_mode = 'unpaired' //alt: paired
-env.n_models = 5 //alt: 1-4
-env.fragment_single_sequence = false
-env.fragment_shuffle_sequence = false
+env.num_models = 5 //alt: 1-4
+env.fragment_single_sequence = false //alt: true, only recognized if lowercase
+env.fragment_shuffle_sequence = false //alt: true, only recognized if lowercase
 
 // Parameters that govern how the output is stored
 env.colabfold_outdir = "output_colabfold"

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -10,6 +10,9 @@ env.alphafold_params_dir = '/home/gridsan/sswanson/localcolabfold/colabfold'
 // Parameters that general don't change (but you can adjust to experiment)
 env.model_type = 'alphafold2_ptm' //alt: alphafold2_multimer_v1 alphafold2_multimer_v2 alphafold2_multimer_v3
 env.pair_mode = 'unpaired' //alt: paired
+env.n_models = 5 //alt: 1-4
+env.fragment_single_sequence = false
+env.fragment_shuffle_sequence = false
 
 // Parameters that govern how the output is stored
 env.colabfold_outdir = "output_colabfold"


### PR DESCRIPTION
Jackson noticed an error in how MSAs are concatenated and contributed a fix, which I will review

The problem is that I used fixed indices (e.g. positions 100-130) to extract the region of the MSA corresponding to the fragment, but this doesn't work if there are insertions (lowercase characters) in the match sequences.