### PR TITLE
Allow flexible naming of protein/fragment parent protein

### DIFF
--- a/fragfold/create_fragment_msa.py
+++ b/fragfold/create_fragment_msa.py
@@ -9,7 +9,7 @@ from fragfold.src.colabfold_create_msa import createIndividualMSAsFullLengthFrag
 def main(args):
     # In either mode, there will be information detailing the fragments
     fragment_a3m = args.fragment_a3m_input
-    fragment_name = Path(fragment_a3m).stem
+    fragment_name = args.fragment_parent_name if args.fragment_parent_name != "" else Path(fragment_a3m).stem 
     fragment_start_range = (args.fragment_ntermres_start,args.fragment_ntermres_final)
     fragment_length = args.fragment_length
     protein_copies = args.protein_copies
@@ -34,7 +34,7 @@ def main(args):
 
         # In heteromeric interaction mode, we parse more arguments
         fulllengthprotein_a3m_path = args.protein_a3m_input
-        fulllengthprotein_name = Path(fulllengthprotein_a3m_path).stem
+        fulllengthprotein_name = args.protein_name if args.protein_name != "" else Path(fulllengthprotein_a3m_path).stem
         msa_path_list = createIndividualMSAsFullLengthFragmentHeteromeric(fulllengthprotein_a3m_path,
                                                                         fulllengthprotein_name,
                                                                         fragment_a3m,
@@ -111,6 +111,18 @@ if __name__ == "__main__":
         "--fragment_shuffle_sequence",
         action='store_true',
         help="If true, will remove the MSA for the fragment and model using the shuffled query sequence",
+    )
+    parser.add_argument(
+        "--fragment_parent_name",
+        type=str,
+        default="",
+        help="If given, the fragment parent will be renamed to this. Otherwise the name of the .a3m file is used",
+    )
+    parser.add_argument(
+        "--protein_name",
+        type=str,
+        default="",
+        help="If given, the protein will be renamed to this. Otherwise the name of the .a3m file is used",
     )
     args = parser.parse_args()
     main(args)

--- a/nextflow/main.nf
+++ b/nextflow/main.nf
@@ -25,7 +25,9 @@ workflow {
                 protein_msa,
                 params.protein_nterm_res,
                 params.protein_cterm_res,
-                params.protein_copies)
+                params.protein_copies,
+                fragment_parent_name,
+                protein_name)
                 | flatten
                 | colabfold
     create_summary_csv(colabfold.out.log | collect , 

--- a/nextflow/modules.nf
+++ b/nextflow/modules.nf
@@ -40,6 +40,8 @@ process process_msa {
         val protein_ntermres
         val protein_ctermres
         val protein_copies
+        val fragment_parent_name
+        val protein_name
 
     output:
         path '*/*.a3m'
@@ -59,6 +61,8 @@ process process_msa {
         --protein_ntermres !{protein_ntermres} \
         --protein_ctermres !{protein_ctermres} \
         --protein_copies !{protein_copies} \
+        --fragment_parent_name !{fragment_parent_name} \
+        --protein_name !{protein_name} \
         $arg1 \
         $arg2 \
     '''
@@ -117,8 +121,8 @@ process create_summary_csv {
     python !{repo_dir}/fragfold/colabfold_process_output.py \
         --predicted_pdbs !{pdb_file} \
         --confidence_logs log_file_*.txt \
-        --full_protein !{protein_name} \
-        --fragment_protein !{fragment_parent_name} \
+        --protein_name !{protein_name} \
+        --fragment_parent_name !{fragment_parent_name} \
         --contact_distance_cutoff !{contact_distance_cutoff} \
         --generate_plots \
         $EXP_DATA_ARG


### PR DESCRIPTION
Previously, the regex used to parse the colabfold output files would fail if the fragment/protein names contained numbers/underscores. Now the regex is defined "on-the-fly" using the exact name of fragment/protein so that any name can be used. 